### PR TITLE
Implement the producer's module

### DIFF
--- a/the-messenger-project/bill-of-materials/pom.xml
+++ b/the-messenger-project/bill-of-materials/pom.xml
@@ -27,12 +27,22 @@
             </dependency>
             <dependency>
                 <groupId>${project.parent.groupId}</groupId>
-                <artifactId>json</artifactId>
+                <artifactId>consumer</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
             <dependency>
                 <groupId>${project.parent.groupId}</groupId>
-                <artifactId>consumer</artifactId>
+                <artifactId>producer</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.parent.groupId}</groupId>
+                <artifactId>transport-json-jackson</artifactId>
+                <version>${project.parent.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.parent.groupId}</groupId>
+                <artifactId>json</artifactId>
                 <version>${project.parent.version}</version>
             </dependency>
         </dependencies>

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/ContentType.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/ContentType.java
@@ -1,13 +1,20 @@
 package com.bellotapps.the_messenger.commons.headers;
 
-import com.bellotapps.the_messenger.commons.ToStringSerializable;
-
 /**
  * Enum containing well-known content types.
  *
  * @see DefinedHeader#CONTENT_TYPE
  */
 public enum ContentType implements ToStringSerializable {
+    /**
+     * Plain text content type.
+     */
+    PLAIN {
+        @Override
+        public String serialize() {
+            return "Plain";
+        }
+    },
     /**
      * JSON content type.
      */

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/DefinedHeader.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/DefinedHeader.java
@@ -1,7 +1,5 @@
 package com.bellotapps.the_messenger.commons.headers;
 
-import com.bellotapps.the_messenger.commons.ToStringSerializable;
-
 /**
  * Enum containing well-known headers.
  */

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/MessageType.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/MessageType.java
@@ -1,7 +1,5 @@
 package com.bellotapps.the_messenger.commons.headers;
 
-import com.bellotapps.the_messenger.commons.ToStringSerializable;
-
 /**
  * Enum containing well-known message types.
  *

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/ToStringSerializable.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/headers/ToStringSerializable.java
@@ -1,8 +1,8 @@
-package com.bellotapps.the_messenger.commons;
+package com.bellotapps.the_messenger.commons.headers;
 
 /**
  * Defines behaviour for an object that can be serialized into a {@link String}.
- * Mostly used for headers and payload of {@link Message}s.
+ * Mostly used for headers and payload of {@link com.bellotapps.the_messenger.commons.Message}s.
  */
 public interface ToStringSerializable {
 

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/ContentTypeHandler.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/ContentTypeHandler.java
@@ -1,0 +1,14 @@
+package com.bellotapps.the_messenger.commons.payload;
+
+/**
+ * Defines behaviour for object that can handle a content type.
+ */
+public interface ContentTypeHandler {
+
+    /**
+     * Indicates the content type that the implementor can handle.
+     *
+     * @return The content type that the implementor can handle.
+     */
+    String contentType();
+}

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/PayloadDeserializer.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/PayloadDeserializer.java
@@ -5,7 +5,7 @@ package com.bellotapps.the_messenger.commons.payload;
  *
  * @param <T> Concrete type of object to be created from the {@link String} to be deserialized.
  */
-public interface PayloadDeserializer<T> {
+public interface PayloadDeserializer<T> extends ContentTypeHandler {
 
     /**
      * Deserializes the given {@code string}.

--- a/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/PayloadSerializer.java
+++ b/the-messenger-project/commons/src/main/java/com/bellotapps/the_messenger/commons/payload/PayloadSerializer.java
@@ -5,7 +5,7 @@ package com.bellotapps.the_messenger.commons.payload;
  *
  * @param <T> Concrete type of object to be serialized.
  */
-public interface PayloadSerializer<T> {
+public interface PayloadSerializer<T> extends ContentTypeHandler {
 
     /**
      * Serializes the given {@code object}.

--- a/the-messenger-project/consumer/src/main/java/com/bellotapps/the_messenger/consumer/DeserializerMessageHandler.java
+++ b/the-messenger-project/consumer/src/main/java/com/bellotapps/the_messenger/consumer/DeserializerMessageHandler.java
@@ -1,8 +1,11 @@
 package com.bellotapps.the_messenger.consumer;
 
 import com.bellotapps.the_messenger.commons.Message;
+import com.bellotapps.the_messenger.commons.headers.DefinedHeader;
 import com.bellotapps.the_messenger.commons.payload.PayloadDeserializationException;
 import com.bellotapps.the_messenger.commons.payload.PayloadDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -15,6 +18,12 @@ import java.util.Optional;
 public abstract class DeserializerMessageHandler<T> implements MessageHandler {
 
     /**
+     * The {@link Logger}.
+     */
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeserializerMessageHandler.class);
+
+
+    /**
      * The {@link PayloadDeserializer} to be used to perform the deserialization phase.
      */
     private final PayloadDeserializer<T> payloadDeserializer;
@@ -22,14 +31,14 @@ public abstract class DeserializerMessageHandler<T> implements MessageHandler {
     /**
      * A {@link MessageHandler} to be invoked in case the deserialization phase fails.
      */
-    private final MessageHandler deserializationExceptionMessageHandler;
+    private final MessageHandler defaultMessageHandler;
 
     /**
      * Constructor.
      *
      * @param payloadDeserializer The {@link PayloadDeserializer} to be used to perform the deserialization phase.
      * @implNote This constructor sets a the {@link DoNothingMessageHandler} as the
-     * {@code deserializationExceptionMessageHandler}.
+     * {@code defaultMessageHandler}.
      */
     protected DeserializerMessageHandler(final PayloadDeserializer<T> payloadDeserializer) {
         this(payloadDeserializer, DoNothingMessageHandler.getInstance());
@@ -38,16 +47,16 @@ public abstract class DeserializerMessageHandler<T> implements MessageHandler {
     /**
      * Constructor.
      *
-     * @param payloadDeserializer                    The {@link PayloadDeserializer}
-     *                                               to be used to perform the deserialization phase.
-     * @param deserializationExceptionMessageHandler A {@link MessageHandler}
-     *                                               to be invoked in case the deserialization phase fails.
+     * @param payloadDeserializer   The {@link PayloadDeserializer}
+     *                              to be used to perform the deserialization phase.
+     * @param defaultMessageHandler A {@link MessageHandler}
+     *                              to be invoked in case the deserialization phase fails.
      */
     protected DeserializerMessageHandler(
             final PayloadDeserializer<T> payloadDeserializer,
-            final MessageHandler deserializationExceptionMessageHandler) {
+            final MessageHandler defaultMessageHandler) {
         this.payloadDeserializer = payloadDeserializer;
-        this.deserializationExceptionMessageHandler = deserializationExceptionMessageHandler;
+        this.defaultMessageHandler = defaultMessageHandler;
     }
 
     @Override
@@ -60,15 +69,36 @@ public abstract class DeserializerMessageHandler<T> implements MessageHandler {
      *
      * @param message The {@link Message} containing the payload to be deserialized.
      * @return An {@link Optional} with the deserialized payload if it could be deserialized, or empty otherwise.
-     * @implNote Will invoke the {@link #deserializationExceptionMessageHandler} if a {@link PayloadDeserializationException}
+     * @implNote Will invoke the {@link #defaultMessageHandler} if a {@link PayloadDeserializationException}
      * is thrown.
      */
     private Optional<T> deserialize(final Message message) {
+        // First check content type
+        final Optional<String> contentType = message.contentType();
+        if (contentType.isPresent()) {
+            // If present, check content types.
+            if (!contentType.get().equals(payloadDeserializer.contentType())) {
+                // Content types are not the same, so deserialization won't be performed.
+                LOGGER.warn(
+                        "DeserializerHandler received a Message with a {} header value " +
+                                "different from the deserializer's. " +
+                                "Message will be handled with the default message handle, " +
+                                "and deserialization won't be performed",
+                        DefinedHeader.CONTENT_TYPE);
+                defaultMessageHandler.handle(message);
+                return Optional.empty();
+            }
+        } else {
+            // If it is not present, just jog
+            LOGGER.warn("DeserializerHandler received a Message without {} header. Will try to deserialize though",
+                    DefinedHeader.CONTENT_TYPE);
+        }
+
         final String payload = message.getPayload();
         try {
             return Optional.ofNullable(payloadDeserializer.deserialize(payload));
         } catch (final PayloadDeserializationException e) {
-            deserializationExceptionMessageHandler.handle(message);
+            defaultMessageHandler.handle(message);
             return Optional.empty();
         }
     }

--- a/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JacksonJsonPayloadDeserializer.java
+++ b/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JacksonJsonPayloadDeserializer.java
@@ -6,11 +6,12 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang3.Validate;
 
 import java.io.IOException;
+import java.util.Optional;
 
 /**
  * A {@link PayloadDeserializer} that delegates deserialization to a Jackson's {@link ObjectMapper}.
  */
-public class JacksonJsonPayloadDeserializer<T> implements PayloadDeserializer<T> {
+public class JacksonJsonPayloadDeserializer<T> implements PayloadDeserializer<T>, JsonContentTypeHandler {
 
     /**
      * The {@link ObjectMapper} to which the deserialization is delegated to.
@@ -38,7 +39,7 @@ public class JacksonJsonPayloadDeserializer<T> implements PayloadDeserializer<T>
     @Override
     public T deserialize(final String string) throws PayloadDeserializationException {
         try {
-            return objectMapper.readValue(string, classToInstantiate);
+            return objectMapper.readValue(Optional.ofNullable(string).orElse("null"), classToInstantiate);
         } catch (final IOException e) {
             throw new PayloadDeserializationException(string, classToInstantiate, e);
         }

--- a/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JacksonJsonPayloadSerializer.java
+++ b/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JacksonJsonPayloadSerializer.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.Validate;
 /**
  * A {@link PayloadSerializer} that delegates serialization to a Jackson's {@link ObjectMapper}.
  */
-public class JacksonJsonPayloadSerializer<T> implements PayloadSerializer<T> {
+public class JacksonJsonPayloadSerializer<T> implements PayloadSerializer<T>, JsonContentTypeHandler {
 
     /**
      * The {@link ObjectMapper} to which the serialization is delegated to.

--- a/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JsonContentTypeHandler.java
+++ b/the-messenger-project/json/src/main/java/com/bellotapps/the_messenger/json/JsonContentTypeHandler.java
@@ -1,0 +1,15 @@
+package com.bellotapps.the_messenger.json;
+
+import com.bellotapps.the_messenger.commons.headers.ContentType;
+import com.bellotapps.the_messenger.commons.payload.ContentTypeHandler;
+
+/**
+ * An extension of {@link ContentTypeHandler} that returns JSON as Content-Type.
+ */
+public interface JsonContentTypeHandler extends ContentTypeHandler {
+
+    @Override
+    default String contentType() {
+        return ContentType.JSON.serialize();
+    }
+}

--- a/the-messenger-project/pom.xml
+++ b/the-messenger-project/pom.xml
@@ -19,6 +19,7 @@
         <module>json</module>
         <module>commons</module>
         <module>consumer</module>
+        <module>producer</module>
         <module>transport-json-jackson</module>
     </modules>
 

--- a/the-messenger-project/producer/pom.xml
+++ b/the-messenger-project/producer/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.bellotapps.the-messenger</groupId>
+        <artifactId>the-messenger-project</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>producer</artifactId>
+    <packaging>jar</packaging>
+    <name>Producer</name>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>commons</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/BiConsumerMessageProducer.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/BiConsumerMessageProducer.java
@@ -1,0 +1,36 @@
+package com.bellotapps.the_messenger.producer;
+
+import com.bellotapps.the_messenger.commons.Message;
+import org.apache.commons.lang3.Validate;
+
+import java.util.function.BiConsumer;
+
+/**
+ * A {@link MessageProducer} that delegates the sending operation to a {@link BiConsumer}
+ * of {@link Message} and a recipient.
+ */
+public class BiConsumerMessageProducer implements MessageProducer {
+
+    /**
+     * The {@link BiConsumer} to which the sending operation is delegated.
+     * It should be stateless.
+     */
+    private final BiConsumer<Message, String> sender;
+
+    /**
+     * Constructor.
+     *
+     * @param sender The {@link BiConsumer} to which the sending operation is delegated. It should be stateless.
+     */
+    public BiConsumerMessageProducer(final BiConsumer<Message, String> sender) {
+        this.sender = sender;
+    }
+
+
+    @Override
+    public void send(final Message message, final String recipient) throws IllegalArgumentException {
+        Validate.isTrue(message != null, "The message must not be null");
+        Validate.isTrue(recipient != null, "The recipient must not be null");
+        sender.accept(message, recipient);
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageBuilder.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageBuilder.java
@@ -1,0 +1,555 @@
+package com.bellotapps.the_messenger.producer;
+
+import com.bellotapps.the_messenger.commons.AbstractMessage;
+import com.bellotapps.the_messenger.commons.Message;
+import com.bellotapps.the_messenger.commons.headers.ContentType;
+import com.bellotapps.the_messenger.commons.headers.DefinedHeader;
+import com.bellotapps.the_messenger.commons.headers.MessageType;
+import com.bellotapps.the_messenger.commons.headers.ToStringSerializable;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializer;
+import com.bellotapps.the_messenger.producer.basic_payload_serializers.ToStringPayloadSerializer;
+import org.apache.commons.lang3.StringUtils;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+/**
+ * A builder of {@link Message}s.
+ *
+ * @param <T> The type of payload.
+ */
+public final class MessageBuilder<T> {
+
+    /**
+     * The id of the {@link Message}.
+     */
+    private String id;
+    /**
+     * The sender of the {@link Message}.
+     */
+    private String sender;
+    /**
+     * The timestamp of the {@link Message}.
+     */
+    private Supplier<Instant> timestampSupplier;
+    /**
+     * The headers of the {@link Message}.
+     */
+    private final Map<String, String> headers;
+    /**
+     * The payload of the {@link Message}, which will be serialized using the {@link #payloadSerializer}.
+     */
+    private T payload;
+    /**
+     * The {@link PayloadSerializer} to transform the {@link #payload} into a {@link String},
+     * to be set to the {@link Message}.
+     */
+    private PayloadSerializer<T> payloadSerializer;
+    /**
+     * The {@link MessageCreator} to be used to instantiate the {@link Message} to be built.
+     */
+    private MessageCreator messageCreator;
+
+
+    /**
+     * Constructor.
+     */
+    public MessageBuilder() {
+        this.headers = new HashMap<>();
+        withRandomId();
+        atBuildTime();
+        withMessageCreator(DefaultMessage::new);
+        usingToStringToSerialize();
+    }
+
+
+    /**
+     * Sets the id of the {@link Message} to be built.
+     *
+     * @param id The id of the {@link Message}.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withId(final String id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Sets a random id to the {@link Message} to be built.
+     *
+     * @return {@code this} for method chaining.
+     * @implNote This methods uses {@link UUID#randomUUID()} for random id generation.
+     */
+    public MessageBuilder<T> withRandomId() {
+        return withId(UUID.randomUUID().toString());
+    }
+
+    /**
+     * Sets the sender of the {@link Message} to be built.
+     *
+     * @param sender The sender of the {@link Message}.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> from(final String sender) {
+        this.sender = sender;
+        return this;
+    }
+
+    /**
+     * Sets the timestamp of the {@link Message} to be built to now.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> atNow() {
+        return at(Instant.now());
+    }
+
+    /**
+     * Sets the timestamp of the {@link Message} to be built.
+     *
+     * @param timestamp The {@link Instant} representing the timestamp of the {@link Message}.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> at(final Instant timestamp) {
+        return atSupplied(() -> timestamp);
+    }
+
+    /**
+     * Makes the builder use {@link Instant#now()} as a {@link Supplier} of {@link Instant}.
+     * This means that the {@link Message} will have as a timestamp the moment it is created
+     * by the {@link #build()} method.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> atBuildTime() {
+        return atSupplied(Instant::now);
+    }
+
+    /**
+     * Sets a {@link Supplier} of {@link Instant} to be used to generate the timestamp of the {@link Message}
+     * to be built. The {@link Supplier#get()} method will be executed when the {@link #build()} method is executed.
+     *
+     * @param timestampSupplier The {@link Supplier} of {@link Instant} to be used.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> atSupplied(final Supplier<Instant> timestampSupplier) {
+        this.timestampSupplier = timestampSupplier;
+        return this;
+    }
+
+    /**
+     * Replaces all the headers in this builders with the given {@code headers}.
+     *
+     * @param headers The new headers {@link Map}.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> replaceHeaders(final Map<String, String> headers) {
+        this.headers.clear();
+        return withHeaders(headers);
+    }
+
+    /**
+     * Adds all the given {@code headers}.
+     *
+     * @param headers The headers to be added.
+     * @return {@code this} for method chaining.
+     * @apiNote This operation overrides already set headers.
+     */
+    public MessageBuilder<T> withHeaders(final Map<String, String> headers) {
+        this.headers.putAll(headers);
+        return this;
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final String key, final String value) {
+        this.headers.put(key, value);
+        return this;
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final ToStringSerializable key, final ToStringSerializable value) {
+        return withHeader(key.serialize(), value.serialize());
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final ToStringSerializable key, final String value) {
+        return withHeader(key.serialize(), value);
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final String key, final ToStringSerializable value) {
+        return withHeader(key, value.serialize());
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final DefinedHeader key, final String value) {
+        return withHeader((ToStringSerializable) key, value);
+    }
+
+    /**
+     * Adds a header to the {@link Message} to be built.
+     *
+     * @param key   The header's key.
+     * @param value The header's value.
+     * @return {@code this} for method chaining.
+     * @apiNote This method replaces the header if the key is already in use.
+     */
+    public MessageBuilder<T> withHeader(final DefinedHeader key, final ToStringSerializable value) {
+        return withHeader((ToStringSerializable) key, value);
+    }
+
+    /**
+     * Specifies the message type (i.e adds the {@link DefinedHeader#MESSAGE_TYPE} header).
+     *
+     * @param type The message type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> messageType(final String type) {
+        return withHeader(DefinedHeader.MESSAGE_TYPE, type);
+    }
+
+    /**
+     * Specifies the message type (i.e adds the {@link DefinedHeader#MESSAGE_TYPE} header).
+     *
+     * @param type The message type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> messageType(final ToStringSerializable type) {
+        return messageType(type.serialize());
+    }
+
+    /**
+     * Specifies the message type (i.e adds the {@link DefinedHeader#MESSAGE_TYPE} header).
+     *
+     * @param type The message type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> messageType(final MessageType type) {
+        return messageType((ToStringSerializable) type);
+    }
+
+
+    /**
+     * Specifies the content type of the payload (i.e adds the {@link DefinedHeader#CONTENT_TYPE} header).
+     *
+     * @param type The content type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> contentType(final String type) {
+        return withHeader(DefinedHeader.CONTENT_TYPE, type);
+    }
+
+    /**
+     * Specifies the content type of the payload (i.e adds the {@link DefinedHeader#CONTENT_TYPE} header).
+     *
+     * @param type The content type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> contentType(final ToStringSerializable type) {
+        return contentType(type.serialize());
+    }
+
+    /**
+     * Specifies the content type of the payload (i.e adds the {@link DefinedHeader#CONTENT_TYPE} header).
+     *
+     * @param type The content type.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> contentType(final ContentType type) {
+        return contentType((ToStringSerializable) type);
+    }
+
+
+    /**
+     * Sets the content type to {@link ContentType#PLAIN}.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> plainText() {
+        return contentType(ContentType.PLAIN);
+    }
+
+    /**
+     * Sets the content type to {@link ContentType#JSON}.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> json() {
+        return contentType(ContentType.JSON);
+    }
+
+
+    /**
+     * Sets the {@link DefinedHeader#REPLIES_TO} header with the given {@code repliedMessageId}.
+     *
+     * @param repliedMessageId The id of the message being replied.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> repliesTo(final String repliedMessageId) {
+        return withHeader(DefinedHeader.REPLIES_TO, repliedMessageId);
+    }
+
+    /**
+     * Sets the {@link DefinedHeader#REPLIES_TO} header with the given {@code repliedMessageId}.
+     *
+     * @param repliedMessageId The id of the message being replied.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> repliesTo(final ToStringSerializable repliedMessageId) {
+        return repliesTo(repliedMessageId.serialize());
+    }
+
+    /**
+     * Sets the {@link DefinedHeader#COMMAND} header with the given {@code command}.
+     *
+     * @param command The command being requested to be executed.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> command(final String command) {
+        return withHeader(DefinedHeader.COMMAND, command);
+    }
+
+    /**
+     * Sets the {@link DefinedHeader#COMMAND} header with the given {@code command}.
+     *
+     * @param command The command being requested to be executed.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> command(final ToStringSerializable command) {
+        return command(command.serialize());
+    }
+
+    /**
+     * Sets the {@link DefinedHeader#COPY_HEADERS} header with the given {@code headersToCopy}.
+     *
+     * @param headersToCopy A list of headers to be copied to the reply message.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> copyHeaders(final String... headersToCopy) {
+        return withHeader(DefinedHeader.COPY_HEADERS, StringUtils.joinWith(", ", (Object[]) headersToCopy));
+    }
+
+    /**
+     * Sets the {@link DefinedHeader#COPY_HEADERS} header with the given {@code headersToCopy}.
+     *
+     * @param headersToCopy A list of headers to be copied to the reply message.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> copyHeaders(final ToStringSerializable... headersToCopy) {
+        return copyHeaders(Arrays.stream(headersToCopy).map(ToStringSerializable::serialize).toArray(String[]::new));
+    }
+
+    /**
+     * Removes the header with the given {@code key} from the {@link Message} to be built.
+     *
+     * @param key The header key to be removed.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withoutHeader(final String key) {
+        this.headers.remove(key);
+        return this;
+    }
+
+    /**
+     * Removes the header with the given {@code key} from the {@link Message} to be built.
+     *
+     * @param key The header key to be removed.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withoutHeader(final ToStringSerializable key) {
+        return withoutHeader(key.serialize());
+    }
+
+    /**
+     * Removes the header with the given {@code key} from the {@link Message} to be built.
+     *
+     * @param key The header key to be removed.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withoutHeader(final DefinedHeader key) {
+        return withoutHeader((ToStringSerializable) key);
+    }
+
+    /**
+     * Removes all headers.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> clearHeaders() {
+        this.headers.clear();
+        return this;
+    }
+
+    /**
+     * Sets the payload of the {@link Message} to be built.
+     *
+     * @param payload The payload of the {@link Message}.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withPayload(final T payload) {
+        this.payload = payload;
+        return this;
+    }
+
+    /**
+     * Sets the {@link PayloadSerializer} to be used to convert the payload into a {@link String}.
+     *
+     * @param serializer The {@link PayloadSerializer} to be used.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withSerializer(final PayloadSerializer<T> serializer) {
+        this.payloadSerializer = serializer;
+        return contentType(serializer.contentType());
+    }
+
+    /**
+     * Sets a {@link ToStringPayloadSerializer} to be used as a {@link PayloadSerializer}.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> usingToStringToSerialize() {
+        return withSerializer(new ToStringPayloadSerializer<>());
+    }
+
+    /**
+     * Sets the message creator used to create the {@link Message} to be built.
+     *
+     * @param messageCreator The {@link MessageCreator} to be used.
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> withMessageCreator(final MessageCreator messageCreator) {
+        this.messageCreator = messageCreator;
+        return this;
+    }
+
+    /**
+     * Clears this builder.
+     *
+     * @return {@code this} for method chaining.
+     */
+    public MessageBuilder<T> clear() {
+        this.id = null;
+        this.sender = null;
+        this.timestampSupplier = null;
+        this.headers.clear();
+        this.payload = null;
+        this.payloadSerializer = null;
+        this.messageCreator = null;
+
+        return this;
+    }
+
+
+    /**
+     * Creates an instance of {@link Message} according to this builder configuration.
+     * Future modifications to this builder won't affect the returned {@link Message}.
+     *
+     * @return An instance of {@link Message}.
+     * @throws IllegalArgumentException If any argument is invalid.
+     */
+    public Message build() throws IllegalArgumentException {
+        return messageCreator.createMessage(
+                id,
+                sender,
+                timestampSupplier.get(),
+                headers,
+                payloadSerializer.serialize(payload)
+        );
+    }
+
+
+    // ================================================================================================================
+    // Helpers
+    // ================================================================================================================
+
+    /**
+     * Defines behaviour for an object that can instantiate {@link Message}s.
+     */
+    @FunctionalInterface
+    public interface MessageCreator {
+
+        /**
+         * Creates a {@link Message}.
+         *
+         * @param id        The id for the {@link Message}.
+         * @param sender    The sender for the {@link Message}.
+         * @param timestamp The timestamp for the {@link Message}.
+         * @param headers   The headers for the {@link Message}.
+         * @param payload   The payload for the {@link Message}.
+         * @return The created {@link Message}.
+         */
+        Message createMessage(
+                final String id,
+                final String sender,
+                final Instant timestamp,
+                final Map<String, String> headers,
+                final String payload
+        );
+    }
+
+    /**
+     * An implementation of {@link Message} to be used in case no {@link MessageCreator} is set
+     * in a {@link MessageBuilder} instance.
+     */
+    public static class DefaultMessage extends AbstractMessage {
+
+        /**
+         * Constructor.
+         *
+         * @param id        The message's id.
+         * @param sender    An identification of the sender. This allows the recipient to know who has sent the message.
+         * @param timestamp The timestamp of the message.
+         * @param headers   The message headers.
+         * @param payload   The message payload.
+         * @throws IllegalArgumentException If any argument is invalid.
+         */
+        private DefaultMessage(
+                final String id,
+                final String sender,
+                final Instant timestamp,
+                final Map<String, String> headers,
+                final String payload) throws IllegalArgumentException {
+            super(id, sender, timestamp, headers, payload);
+        }
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageBuilderFactory.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageBuilderFactory.java
@@ -1,0 +1,70 @@
+package com.bellotapps.the_messenger.producer;
+
+import com.bellotapps.the_messenger.commons.Message;
+import com.bellotapps.the_messenger.commons.headers.MessageType;
+
+/**
+ * Defines behaviour for an object that can create instances of {@link MessageBuilder}s of a given type of payload.
+ *
+ * @param <T> The type of payload to be set in the {@link Message}s built with the created {@link MessageBuilder}s.
+ */
+public interface MessageBuilderFactory<T> {
+
+    /**
+     * Creates a new builder instance.
+     *
+     * @return A new builder instance.
+     */
+    default MessageBuilder<T> create() {
+        return new MessageBuilder<>();
+    }
+
+    /**
+     * Creates a new builder instance, preconfigured to be a simple message.
+     *
+     * @return A new builder instance, preconfigured to be a simple message.
+     * @see MessageType#SIMPLE
+     */
+    default MessageBuilder<T> simpleMessage() {
+        return this.create()
+                .messageType(MessageType.SIMPLE);
+    }
+
+    /**
+     * Creates a new builder instance, preconfigured to be a reply message.
+     *
+     * @param repliedMessageId The id of the message being replied.
+     * @return A new builder instance, preconfigured to be a reply message.
+     * @see MessageType#REPLY
+     */
+    default MessageBuilder<T> replyMessage(final String repliedMessageId) {
+        return this.create()
+                .messageType(MessageType.REPLY)
+                .repliesTo(repliedMessageId);
+    }
+
+    /**
+     * Creates a new builder instance, preconfigured to be a reply message.
+     *
+     * @param repliedMessage The {@link Message} being replied.
+     * @return A new builder instance, preconfigured to be a reply message.
+     * @see MessageType#REPLY
+     */
+    default MessageBuilder<T> replyMessage(final Message repliedMessage) {
+        return this.replyMessage(repliedMessage.getId())
+                .withHeaders(repliedMessage.copyHeadersKeysAndValues());
+    }
+
+    /**
+     * Creates a new builder instance, preconfigured to be a command message.
+     *
+     * @param command The command being requested to be executed.
+     * @return A new builder instance, preconfigured to be a command message.
+     * @see MessageType#SIMPLE
+     */
+    default MessageBuilder<T> commandMessage(final String command) {
+        return this.create()
+                .messageType(MessageType.COMMAND)
+                .command(command);
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageProducer.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/MessageProducer.java
@@ -1,0 +1,18 @@
+package com.bellotapps.the_messenger.producer;
+
+import com.bellotapps.the_messenger.commons.Message;
+
+/**
+ * Defines behaviour for objects that can send {@link Message}s.
+ */
+public interface MessageProducer {
+
+    /**
+     * Sends the given {@code message} to the given {@code recipient}.
+     *
+     * @param message   The {@link Message} to be sent.
+     * @param recipient The destination of the given {@code message}.
+     * @throws IllegalArgumentException If the given {@code message} or {@code recipient} are null.
+     */
+    void send(final Message message, final String recipient) throws IllegalArgumentException;
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/GenericMessageBuilderFactory.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/GenericMessageBuilderFactory.java
@@ -1,0 +1,56 @@
+package com.bellotapps.the_messenger.producer.basic_factories;
+
+import com.bellotapps.the_messenger.commons.Message;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializer;
+import com.bellotapps.the_messenger.producer.MessageBuilder;
+import com.bellotapps.the_messenger.producer.MessageBuilderFactory;
+
+/**
+ * An implementation of {@link MessageBuilderFactory} that allows creating {@link MessageBuilder}s
+ * with a sender, a {@link PayloadSerializer}, and a {@link MessageBuilder.MessageCreator} preconfigured.
+ *
+ * @param <T> The type of payload to be set in the {@link Message}s built with the created {@link MessageBuilder}s.
+ */
+public class GenericMessageBuilderFactory<T> implements MessageBuilderFactory<T> {
+
+    /**
+     * The sender to be configured to the created {@link MessageBuilder}s.
+     */
+    private final String sender;
+    /**
+     * The {@link PayloadSerializer} to be configured to the created {@link MessageBuilder}s.
+     */
+    private final PayloadSerializer<T> serializer;
+    /**
+     * The {@link MessageBuilder.MessageCreator} to be configured to the created {@link MessageBuilder}s.
+     */
+    private final MessageBuilder.MessageCreator messageCreator;
+
+
+    /**
+     * Constructor.
+     *
+     * @param sender         The sender to be configured to the created {@link MessageBuilder}s.
+     * @param serializer     The {@link PayloadSerializer} to be configured to the created {@link MessageBuilder}s.
+     * @param messageCreator The {@link MessageBuilder.MessageCreator}
+     *                       to be configured to the created {@link MessageBuilder}s.
+     */
+    public GenericMessageBuilderFactory(
+            final String sender,
+            final PayloadSerializer<T> serializer,
+            final MessageBuilder.MessageCreator messageCreator) {
+        this.sender = sender;
+        this.serializer = serializer;
+        this.messageCreator = messageCreator;
+    }
+
+
+    @Override
+    public MessageBuilder<T> create() {
+        return MessageBuilderFactory.super.create()
+                .from(sender)
+                .withSerializer(serializer)
+                .contentType(serializer.contentType())
+                .withMessageCreator(messageCreator);
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/StringPayloadMessageBuilderFactory.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/StringPayloadMessageBuilderFactory.java
@@ -1,0 +1,36 @@
+package com.bellotapps.the_messenger.producer.basic_factories;
+
+import com.bellotapps.the_messenger.producer.MessageBuilder;
+import com.bellotapps.the_messenger.producer.basic_payload_serializers.PlainPayloadSerializer;
+
+/**
+ * An extension of a {@link GenericMessageBuilderFactory} that creates {@link MessageBuilder}s of {@link String},
+ * using a {@link PlainPayloadSerializer}.
+ */
+public class StringPayloadMessageBuilderFactory extends GenericMessageBuilderFactory<String> {
+
+    /**
+     * The sender to be configured to the created {@link MessageBuilder}s.
+     */
+    private final String sender;
+    /**
+     * The {@link MessageBuilder.MessageCreator} to be configured to the created {@link MessageBuilder}s.
+     */
+    private final MessageBuilder.MessageCreator messageCreator;
+
+
+    /**
+     * Constructor.
+     *
+     * @param sender         The sender to be configured to the created {@link MessageBuilder}s.
+     * @param messageCreator The {@link MessageBuilder.MessageCreator}
+     *                       to be configured to the created {@link MessageBuilder}s.
+     */
+    public StringPayloadMessageBuilderFactory(
+            final String sender,
+            final MessageBuilder.MessageCreator messageCreator) {
+        super(sender, new PlainPayloadSerializer(), messageCreator);
+        this.sender = sender;
+        this.messageCreator = messageCreator;
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/ToStringPayloadMessageBuilderFactory.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/ToStringPayloadMessageBuilderFactory.java
@@ -1,0 +1,36 @@
+package com.bellotapps.the_messenger.producer.basic_factories;
+
+import com.bellotapps.the_messenger.producer.MessageBuilder;
+import com.bellotapps.the_messenger.producer.basic_payload_serializers.ToStringPayloadSerializer;
+
+/**
+ * An extension of a {@link GenericMessageBuilderFactory} that creates {@link MessageBuilder}s of {@link String},
+ * * using a {@link ToStringPayloadSerializer}.
+ */
+public class ToStringPayloadMessageBuilderFactory<T> extends GenericMessageBuilderFactory<T> {
+
+    /**
+     * The sender to be configured to the created {@link MessageBuilder}s.
+     */
+    private final String sender;
+    /**
+     * The {@link MessageBuilder.MessageCreator} to be configured to the created {@link MessageBuilder}s.
+     */
+    private final MessageBuilder.MessageCreator messageCreator;
+
+
+    /**
+     * Constructor.
+     *
+     * @param sender         The sender to be configured to the created {@link MessageBuilder}s.
+     * @param messageCreator The {@link MessageBuilder.MessageCreator}
+     *                       to be configured to the created {@link MessageBuilder}s.
+     */
+    public ToStringPayloadMessageBuilderFactory(
+            final String sender,
+            final MessageBuilder.MessageCreator messageCreator) {
+        super(sender, new ToStringPayloadSerializer<>(), messageCreator);
+        this.sender = sender;
+        this.messageCreator = messageCreator;
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/ToStringSerializablePayloadMessageBuilderFactory.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_factories/ToStringSerializablePayloadMessageBuilderFactory.java
@@ -1,0 +1,37 @@
+package com.bellotapps.the_messenger.producer.basic_factories;
+
+import com.bellotapps.the_messenger.commons.headers.ToStringSerializable;
+import com.bellotapps.the_messenger.producer.MessageBuilder;
+import com.bellotapps.the_messenger.producer.basic_payload_serializers.ToStringSerializablePayloadSerializer;
+
+/**
+ * An extension of a {@link GenericMessageBuilderFactory} that creates {@link MessageBuilder}s of {@link String},
+ * * using a {@link ToStringSerializablePayloadSerializer}.
+ */
+public class ToStringSerializablePayloadMessageBuilderFactory extends GenericMessageBuilderFactory<ToStringSerializable> {
+
+    /**
+     * The sender to be configured to the created {@link MessageBuilder}s.
+     */
+    private final String sender;
+    /**
+     * The {@link MessageBuilder.MessageCreator} to be configured to the created {@link MessageBuilder}s.
+     */
+    private final MessageBuilder.MessageCreator messageCreator;
+
+
+    /**
+     * Constructor.
+     *
+     * @param sender         The sender to be configured to the created {@link MessageBuilder}s.
+     * @param messageCreator The {@link MessageBuilder.MessageCreator}
+     *                       to be configured to the created {@link MessageBuilder}s.
+     */
+    public ToStringSerializablePayloadMessageBuilderFactory(
+            final String sender,
+            final MessageBuilder.MessageCreator messageCreator) {
+        super(sender, new ToStringSerializablePayloadSerializer(), messageCreator);
+        this.sender = sender;
+        this.messageCreator = messageCreator;
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/PlainContentTypeHandler.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/PlainContentTypeHandler.java
@@ -1,0 +1,15 @@
+package com.bellotapps.the_messenger.producer.basic_payload_serializers;
+
+import com.bellotapps.the_messenger.commons.headers.ContentType;
+import com.bellotapps.the_messenger.commons.payload.ContentTypeHandler;
+
+/**
+ * An extension of {@link ContentTypeHandler} that returns Plain as Content-Type.
+ */
+public interface PlainContentTypeHandler extends ContentTypeHandler {
+
+    @Override
+    default String contentType() {
+        return ContentType.PLAIN.serialize();
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/PlainPayloadSerializer.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/PlainPayloadSerializer.java
@@ -1,0 +1,16 @@
+package com.bellotapps.the_messenger.producer.basic_payload_serializers;
+
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializationException;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializer;
+
+/**
+ * A {@link PayloadSerializer} for {@link String} payload objects.
+ * It just returns the same instance of the {@link String}.
+ */
+public class PlainPayloadSerializer implements PayloadSerializer<String>, PlainContentTypeHandler {
+
+    @Override
+    public String serialize(final String object) throws PayloadSerializationException {
+        return object;
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/ToStringPayloadSerializer.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/ToStringPayloadSerializer.java
@@ -1,0 +1,20 @@
+package com.bellotapps.the_messenger.producer.basic_payload_serializers;
+
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializationException;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializer;
+
+import java.util.Objects;
+
+/**
+ * A {@link PayloadSerializer} for payload objects of type {@code T}.
+ * It uses the {@link Objects#toString(Object)} method to convert the objects into {@link String}s.
+ *
+ * @param <T> Concrete type of object to be serialized.
+ */
+public class ToStringPayloadSerializer<T> implements PayloadSerializer<T>, PlainContentTypeHandler {
+
+    @Override
+    public String serialize(final T object) throws PayloadSerializationException {
+        return Objects.toString(object);
+    }
+}

--- a/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/ToStringSerializablePayloadSerializer.java
+++ b/the-messenger-project/producer/src/main/java/com/bellotapps/the_messenger/producer/basic_payload_serializers/ToStringSerializablePayloadSerializer.java
@@ -1,0 +1,18 @@
+package com.bellotapps.the_messenger.producer.basic_payload_serializers;
+
+import com.bellotapps.the_messenger.commons.headers.ToStringSerializable;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializationException;
+import com.bellotapps.the_messenger.commons.payload.PayloadSerializer;
+
+/**
+ * A {@link PayloadSerializer} for {@link ToStringSerializable} payload objects.
+ * Uses the {@link ToStringSerializable#serialize()} to serialize the payloads.
+ */
+public class ToStringSerializablePayloadSerializer
+        implements PayloadSerializer<ToStringSerializable>, PlainContentTypeHandler {
+
+    @Override
+    public String serialize(final ToStringSerializable object) throws PayloadSerializationException {
+        return object.serialize();
+    }
+}


### PR DESCRIPTION
- Also big improvement in code structure, which includes:
  - Add a Jackson Serialization module (remove Jackson from commons, allowing any kind of serialization of messages)
  - Move the MessageBuilder to the Producer, and create a MessageBuilderFactory interface